### PR TITLE
Use existing credentials framework of jenkins

### DIFF
--- a/jclouds-plugin/pom.xml
+++ b/jclouds-plugin/pom.xml
@@ -185,6 +185,23 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>2.5.2</version>
+                <configuration>
+                    <excludeFilterFile>src/findbugs/excludesFilter.xml</excludeFilterFile>
+                    <failOnError>false</failOnError>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <scm>

--- a/jclouds-plugin/pom.xml
+++ b/jclouds-plugin/pom.xml
@@ -186,6 +186,23 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                            <goal>cpd-check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failOnViolation>false</failOnViolation>
+                    <verbose>true</verbose>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
                 <version>2.5.2</version>

--- a/jclouds-plugin/pom.xml
+++ b/jclouds-plugin/pom.xml
@@ -221,6 +221,15 @@
             </plugin>
         </plugins>
     </build>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jxr-plugin</artifactId>
+                <version>2.3</version>
+            </plugin>
+        </plugins>
+    </reporting>
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/jclouds-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/jclouds-plugin.git</developerConnection>

--- a/jclouds-plugin/src/findbugs/excludesFilter.xml
+++ b/jclouds-plugin/src/findbugs/excludesFilter.xml
@@ -1,0 +1,5 @@
+<FindBugsFilter>
+  <Match>
+    <Class name="~.*\.Messages"/>
+  </Match>
+</FindBugsFilter>

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
@@ -209,7 +209,7 @@ public class JCloudsCloud extends Cloud {
                     ensureLaunched(jcloudsSlave);
                     return jcloudsSlave;
                 }
-            }), Util.tryParseNumber(template.numExecutors, 1).intValue()));
+            }), template.getNumExecutors()));
             excessWorkload -= template.getNumExecutors();
         }
         return plannedNodeList;

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
@@ -130,7 +130,7 @@ public class JCloudsCloud extends Cloud {
     }
 
     public String getGlobalPrivateKey() {
-        if (null == cloudGlobalKeyId) {
+        if (Strings.isNullOrEmpty(cloudGlobalKeyId)) {
             return "";
         }
         SSHUserPrivateKey supk = CredentialsMatchers.firstOrNull(
@@ -528,11 +528,7 @@ public class JCloudsCloud extends Cloud {
         }
 
         @Override protected void callback(JCloudsCloud c, UnmarshallingContext context) {
-            // if (null == c.getCloudCredentialsId() && null != c.identity && null != c.credential) {
-            //     c.setCloudCredentialsId(convertCloudCredentials(c.name, c.identity, c.credential));
-            // }
-
-            if (null == c.getCloudGlobalKeyId() && null != c.privateKey && !c.privateKey.isEmpty()) {
+            if (Strings.isNullOrEmpty(c.getCloudGlobalKeyId()) && !Strings.isNullOrEmpty(c.privateKey)) {
                 c.setCloudGlobalKeyId(convertCloudPrivateKey(c.name, c.privateKey));
             }
             for (JCloudsSlaveTemplate t : c.templates) {

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
@@ -2,15 +2,12 @@ package jenkins.plugins.jclouds.compute;
 
 import javax.annotation.Nullable;
 import javax.servlet.ServletException;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -46,7 +43,6 @@ import org.jclouds.enterprise.config.EnterpriseConfigurationModule;
 import org.jclouds.location.reference.LocationConstants;
 import org.jclouds.logging.jdk.config.JDKLoggingModule;
 import org.jclouds.providers.Providers;
-import org.jclouds.ssh.SshKeys;
 import org.jclouds.sshj.config.SshjSshClientModule;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.AncestorInPath;
@@ -82,7 +78,6 @@ import jenkins.plugins.jclouds.internal.SSHPublicKeyExtractor;
 
 import hudson.util.XStream2;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
-import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 
 /**
  * The JClouds version of the Jenkins Cloud.

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
@@ -23,6 +23,7 @@ import hudson.model.AutoCompletionCandidates;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Hudson;
+import hudson.model.ItemGroup;
 import hudson.model.Label;
 import hudson.model.Node;
 import hudson.slaves.Cloud;
@@ -48,6 +49,7 @@ import org.jclouds.providers.Providers;
 import org.jclouds.ssh.SshKeys;
 import org.jclouds.sshj.config.SshjSshClientModule;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -59,6 +61,28 @@ import shaded.com.google.common.collect.ImmutableSet.Builder;
 import shaded.com.google.common.collect.ImmutableSortedSet;
 import shaded.com.google.common.collect.Iterables;
 import shaded.com.google.common.io.Closeables;
+
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
+import org.acegisecurity.context.SecurityContext;
+import hudson.security.ACL;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import org.acegisecurity.context.SecurityContextHolder;
+import hudson.security.AccessControlled;
+
+import jenkins.plugins.jclouds.internal.SSHPublicKeyExtractor;
+
+import hudson.util.XStream2;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 
 /**
  * The JClouds version of the Jenkins Cloud.
@@ -85,6 +109,8 @@ public class JCloudsCloud extends Cloud {
     private transient ComputeService compute;
     public final String zones;
 
+    private String cloudGlobalKeyId;
+
     public static List<String> getCloudNames() {
         List<String> cloudNames = new ArrayList<String>();
         for (Cloud c : Hudson.getInstance().clouds) {
@@ -100,17 +126,48 @@ public class JCloudsCloud extends Cloud {
         return (JCloudsCloud) Hudson.getInstance().clouds.getByName(name);
     }
 
+    public String getCloudGlobalKeyId() {
+        return cloudGlobalKeyId;
+    }
+
+    public void setCloudGlobalKeyId(final String value) {
+        cloudGlobalKeyId = value;
+    }
+
+    public String getGlobalPrivateKey() {
+        if (null == cloudGlobalKeyId) {
+            return "";
+        }
+        SSHUserPrivateKey supk = CredentialsMatchers.firstOrNull(
+                CredentialsProvider.lookupCredentials(SSHUserPrivateKey.class, Hudson.getInstance(), ACL.SYSTEM, null),
+                CredentialsMatchers.withId(cloudGlobalKeyId));
+        if (null != supk) {
+            return supk.getPrivateKey();
+        }
+        return "";
+    }
+
+    public String getGlobalPublicKey() {
+        try {
+            return SSHPublicKeyExtractor.extract(getGlobalPrivateKey(), null);
+        } catch (IOException e) {
+            LOGGER.warning(String.format("Error while extracting public key: %s", e));
+        }
+        return "";
+    }
+
     @DataBoundConstructor
-    public JCloudsCloud(final String profile, final String providerName, final String identity, final String credential, final String privateKey,
-                        final String publicKey, final String endPointUrl, final int instanceCap, final int retentionTime, final int scriptTimeout, final int startTimeout,
-                        final String zones, final List<JCloudsSlaveTemplate> templates) {
+    public JCloudsCloud(final String profile, final String providerName, final String identity, final String credential, final String cloudGlobalKeyId,
+            final String endPointUrl, final int instanceCap, final int retentionTime, final int scriptTimeout, final int startTimeout,
+            final String zones, final List<JCloudsSlaveTemplate> templates) {
         super(Util.fixEmptyAndTrim(profile));
         this.profile = Util.fixEmptyAndTrim(profile);
         this.providerName = Util.fixEmptyAndTrim(providerName);
         this.identity = Util.fixEmptyAndTrim(identity);
         this.credential = Secret.fromString(credential);
-        this.privateKey = privateKey;
-        this.publicKey = publicKey;
+        this.privateKey = null; // No longer used
+        this.publicKey = null; // No longer used
+        this.cloudGlobalKeyId = cloudGlobalKeyId;
         this.endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
         this.instanceCap = instanceCap;
         this.retentionTime = retentionTime;
@@ -122,8 +179,9 @@ public class JCloudsCloud extends Cloud {
     }
 
     protected Object readResolve() {
-        for (JCloudsSlaveTemplate template : templates)
+        for (JCloudsSlaveTemplate template : templates) {
             template.cloud = this;
+        }
         return this;
     }
 
@@ -156,7 +214,7 @@ public class JCloudsCloud extends Cloud {
         // correct the classloader so that extensions can be found
         Thread.currentThread().setContextClassLoader(Apis.class.getClassLoader());
         return ContextBuilder.newBuilder(providerName).credentials(identity, credential).overrides(overrides).modules(MODULES)
-                .buildView(ComputeServiceContext.class);
+            .buildView(ComputeServiceContext.class);
     }
 
     public ComputeService getCompute() {
@@ -202,10 +260,10 @@ public class JCloudsCloud extends Cloud {
                     Jenkins.getInstance().addNode(jcloudsSlave);
 
                     /* Cloud instances may have a long init script. If we declare the provisioning complete by returning
-                    without the connect operation, NodeProvisioner may decide that it still wants one more instance,
-                    because it sees that (1) all the slaves are offline (because it's still being launched) and (2)
-                    there's no capacity provisioned yet. Deferring the completion of provisioning until the launch goes
-                    successful prevents this problem.  */
+                       without the connect operation, NodeProvisioner may decide that it still wants one more instance,
+                       because it sees that (1) all the slaves are offline (because it's still being launched) and (2)
+                       there's no capacity provisioned yet. Deferring the completion of provisioning until the launch goes
+                       successful prevents this problem.  */
                     ensureLaunched(jcloudsSlave);
                     return jcloudsSlave;
                 }
@@ -272,27 +330,27 @@ public class JCloudsCloud extends Cloud {
      * @throws Descriptor.FormException
      */
     public void doProvision(StaplerRequest req, StaplerResponse rsp, @QueryParameter String name) throws ServletException, IOException,
-            Descriptor.FormException {
-        checkPermission(PROVISION);
-        if (name == null) {
-            sendError("The slave template name query parameter is missing", req, rsp);
-            return;
-        }
-        JCloudsSlaveTemplate t = getTemplate(name);
-        if (t == null) {
-            sendError("No such slave template with name : " + name, req, rsp);
-            return;
-        }
+           Descriptor.FormException {
+               checkPermission(PROVISION);
+               if (name == null) {
+                   sendError("The slave template name query parameter is missing", req, rsp);
+                   return;
+               }
+               JCloudsSlaveTemplate t = getTemplate(name);
+               if (t == null) {
+                   sendError("No such slave template with name : " + name, req, rsp);
+                   return;
+               }
 
-        if (getRunningNodesCount() < instanceCap) {
-            StringWriter sw = new StringWriter();
-            StreamTaskListener listener = new StreamTaskListener(sw);
-            JCloudsSlave node = t.provisionSlave(listener);
-            Hudson.getInstance().addNode(node);
-            rsp.sendRedirect2(req.getContextPath() + "/computer/" + node.getNodeName());
-        } else {
-            sendError("Instance cap for this cloud is now reached for cloud profile: " + profile + " for template type " + name, req, rsp);
-        }
+               if (getRunningNodesCount() < instanceCap) {
+                   StringWriter sw = new StringWriter();
+                   StreamTaskListener listener = new StreamTaskListener(sw);
+                   JCloudsSlave node = t.provisionSlave(listener);
+                   Hudson.getInstance().addNode(node);
+                   rsp.sendRedirect2(req.getContextPath() + "/computer/" + node.getNodeName());
+               } else {
+                   sendError("Instance cap for this cloud is now reached for cloud profile: " + profile + " for template type " + name, req, rsp);
+               }
     }
 
     /**
@@ -308,7 +366,7 @@ public class JCloudsCloud extends Cloud {
                 if (getTemplate(nodeGroup) != null && !((NodeMetadata) cm).getStatus().equals(NodeMetadata.Status.SUSPENDED)
                         && !((NodeMetadata) cm).getStatus().equals(NodeMetadata.Status.TERMINATED)) {
                     nodeCount++;
-                }
+                        }
             }
         }
         return nodeCount;
@@ -326,13 +384,13 @@ public class JCloudsCloud extends Cloud {
         }
 
         public FormValidation doTestConnection(@QueryParameter String providerName, @QueryParameter String identity, @QueryParameter String credential,
-                                               @QueryParameter String privateKey, @QueryParameter String endPointUrl, @QueryParameter String zones)  throws IOException {
+                @QueryParameter String cloudGlobalKeyId, @QueryParameter String endPointUrl, @QueryParameter String zones)  throws IOException {
             if (identity == null)
-                return FormValidation.error("Invalid (AccessId).");
+               return FormValidation.error("Invalid (AccessId).");
             if (credential == null)
-                return FormValidation.error("Invalid credential (secret key).");
-            if (privateKey == null)
-                return FormValidation.error("Private key is not specified. Click 'Generate Key' to generate one.");
+               return FormValidation.error("Invalid credential (secret key).");
+            //if (privateKey == null)
+            //   return FormValidation.error("Private key is not specified. Click 'Generate Key' to generate one.");
 
             // Remove empty text/whitespace from the fields.
             providerName = Util.fixEmptyAndTrim(providerName);
@@ -360,32 +418,6 @@ public class JCloudsCloud extends Cloud {
             return result;
         }
 
-        public FormValidation doGenerateKeyPair(StaplerResponse rsp, String identity, String credential) throws IOException, ServletException {
-            Map<String, String> keyPair = SshKeys.generate();
-            rsp.addHeader("script", "findPreviousFormItem(button,'privateKey').value='" + keyPair.get("private").replace("\n", "\\n") + "';"
-                    + "findPreviousFormItem(button,'publicKey').value='" + keyPair.get("public").replace("\n", "\\n") + "';");
-            return FormValidation.ok("Successfully generated private Key!");
-        }
-
-        public FormValidation doCheckPrivateKey(@QueryParameter String value) throws IOException, ServletException {
-            boolean hasStart = false, hasEnd = false;
-            BufferedReader br = new BufferedReader(new StringReader(value));
-            String line;
-            while ((line = br.readLine()) != null) {
-                if (line.equals("-----BEGIN RSA PRIVATE KEY-----"))
-                    hasStart = true;
-                if (line.equals("-----END RSA PRIVATE KEY-----"))
-                    hasEnd = true;
-            }
-            if (!hasStart)
-                return FormValidation.error("Please make sure that the private key starts with '-----BEGIN RSA PRIVATE KEY-----'");
-            if (!hasEnd)
-                return FormValidation.error("The private key is missing the trailing 'END RSA PRIVATE KEY' marker. Copy&paste error?");
-            if (SshKeys.fingerprintPrivateKey(value) == null)
-                return FormValidation.error("Invalid private key, please check again or click on 'Generate Key' to generate a new key");
-            return FormValidation.ok();
-        }
-
         public ListBoxModel doFillProviderNameItems() {
             ListBoxModel m = new ListBoxModel();
 
@@ -402,6 +434,22 @@ public class JCloudsCloud extends Cloud {
                 m.add(supportedProvider, supportedProvider);
             }
             return m;
+        }
+
+        public ListBoxModel  doFillCloudCredentialsIdItems(@AncestorInPath ItemGroup context) {
+            if (!(context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance()).hasPermission(Computer.CONFIGURE)) {
+                return new ListBoxModel();
+            }
+            return new StandardUsernameListBoxModel().withAll(
+                CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class, context, ACL.SYSTEM, null));
+        }
+
+        public ListBoxModel  doFillCloudGlobalKeyIdItems(@AncestorInPath ItemGroup context) {
+            if (!(context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance()).hasPermission(Computer.CONFIGURE)) {
+                return new ListBoxModel();
+            }
+            return new StandardUsernameListBoxModel().withAll(
+                    CredentialsProvider.lookupCredentials(SSHUserPrivateKey.class, context, ACL.SYSTEM, null));
         }
 
         public AutoCompletionCandidates doAutoCompleteProviderName(@QueryParameter final String value) {
@@ -475,4 +523,83 @@ public class JCloudsCloud extends Cloud {
             return FormValidation.ok();
         }
     }
+
+    public static class ConverterImpl extends XStream2.PassthruConverter<JCloudsCloud> {
+
+        static final Logger LOGGER = Logger.getLogger(ConverterImpl.class.getName());
+
+        public ConverterImpl(XStream2 xstream) {
+            super(xstream);
+        }
+
+        @Override protected void callback(JCloudsCloud c, UnmarshallingContext context) {
+            // if (null == c.getCloudCredentialsId() && null != c.identity && null != c.credential) {
+            //     c.setCloudCredentialsId(convertCloudCredentials(c.name, c.identity, c.credential));
+            // }
+
+            if (null == c.getCloudGlobalKeyId() && null != c.privateKey && !c.privateKey.isEmpty()) {
+                c.setCloudGlobalKeyId(convertCloudPrivateKey(c.name, c.privateKey));
+            }
+            for (JCloudsSlaveTemplate t : c.templates) {
+                t.upgrade();
+            }
+        }
+
+        /**
+         * Converts the old identity/credential pair into a new credential-plugin record.
+         * @param credential The name of the JCloudsCloud.
+         * @param identity The old username.
+         * @param credential The old password.
+         * @return The Id of the newly created  credential-plugin record.
+         */
+        private String convertCloudCredentials(final String name, final String identity, final String credential) {
+            final String username = Util.fixEmptyAndTrim(identity);
+            final String password = Secret.fromString(credential).getPlainText();
+            final String description = "Converted cloud credentials for \"" + name + "\"";
+            StandardUsernameCredentials u =
+                new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, null, description, username, password);
+            final SecurityContext previousContext = ACL.impersonate(ACL.SYSTEM);
+            try {
+                CredentialsStore s = CredentialsProvider.lookupStores(Jenkins.getInstance()).iterator().next();
+                try {
+                    s.addCredentials(Domain.global(), u);
+                    return u.getId();
+                } catch (IOException e) {
+                    // ignore
+                }
+            } finally {
+                SecurityContextHolder.setContext(previousContext);
+            }
+            return null;
+        }
+
+        /**
+         * Converts the old privateKey into a new ssh-credential-plugin record.
+         * The name of this cloud instance is used as username.
+         * @param credential The name of the JCloudsCloud.
+         * @param privateKey The old privateKey.
+         * @return The Id of the newly created  ssh-credential-plugin record.
+         */
+        public String convertCloudPrivateKey(final String name, final String privateKey) {
+            final String description = "JClouds cloud " + name + " - auto-migrated";
+            StandardUsernameCredentials u =
+                new BasicSSHUserPrivateKey(CredentialsScope.SYSTEM, null, "Global key",
+                        new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(privateKey), null, description);
+            final SecurityContext previousContext = ACL.impersonate(ACL.SYSTEM);
+            try {
+                CredentialsStore s = CredentialsProvider.lookupStores(Jenkins.getInstance()).iterator().next();
+                try {
+                    s.addCredentials(Domain.global(), u);
+                    return u.getId();
+                } catch (IOException e) {
+                    // ignore
+                }
+            } finally {
+                SecurityContextHolder.setContext(previousContext);
+            }
+            return null;
+        }
+
+    }
+
 }

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -213,10 +213,10 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
     }
 
     public String getJenkinsUser() {
-        if (null != jenkinsUser && jenkinsUser.isEmpty()) {
+        if (!Strings.isNullOrEmpty(jenkinsUser)) {
             return jenkinsUser;
         }
-        if (null == credentialsId
+        if (Strings.isNullOrEmpty(credentialsId)
                 || null == SSHLauncher.lookupSystemCredentials(credentialsId)
                 || null == Util.fixEmptyAndTrim(SSHLauncher.lookupSystemCredentials(credentialsId).getUsername())) {
             return "jenkins";
@@ -226,7 +226,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
     }
 
     public String getJenkinsPrivateKey() {
-        if (null == credentialsId) {
+        if (Strings.isNullOrEmpty(credentialsId)) {
             return getCloud().getGlobalPrivateKey();
         }
         SSHUserPrivateKey supk = CredentialsMatchers.firstOrNull(
@@ -251,7 +251,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
         if (!Strings.isNullOrEmpty(vmUser)) {
             return vmUser;
         }
-        if (null == adminCredentialsId
+        if (Strings.isNullOrEmpty(adminCredentialsId)
                 || null == SSHLauncher.lookupSystemCredentials(adminCredentialsId)
                 || null == Util.fixEmptyAndTrim(SSHLauncher.lookupSystemCredentials(adminCredentialsId).getUsername())) {
             return "root";
@@ -834,11 +834,11 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
         try {
             final String description = "JClouds cloud " + getCloud().name + "." + name + " - auto-migrated";
             String ju = getJenkinsUser();
-            if (null == getCredentialsId() && null != ju && !ju.isEmpty()) {
+            if (Strings.isNullOrEmpty(getCredentialsId()) && !Strings.isNullOrEmpty(ju)) {
                 setCredentialsId(convertJenkinsUser(ju, description, getCloud().getGlobalPrivateKey()));
                 jenkinsUser = null; // Not used anymore;
             }
-            if (null == getAdminCredentialsId()) {
+            if (Strings.isNullOrEmpty(getAdminCredentialsId())) {
                 StandardUsernameCredentials u = null;
                 String au = getAdminUser();
                 if (Strings.isNullOrEmpty(vmPassword)) {

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -62,7 +62,6 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
-
 import au.com.bytecode.opencsv.CSVReader;
 import shaded.com.google.common.base.Strings;
 import shaded.com.google.common.base.Supplier;
@@ -368,7 +367,6 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
             if (null != c) {
                 if (c instanceof StandardUsernamePasswordCredentials) {
                     String password = ((StandardUsernamePasswordCredentials)c).getPassword().toString();
-                    LOGGER.info("password=" + password);
                     LoginCredentials lc = LoginCredentials.builder().user(adminUser).password(password).build();
                     options.overrideLoginCredentials(lc);
                 } else {

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/internal/SSHPublicKeyExtractor.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/internal/SSHPublicKeyExtractor.java
@@ -1,0 +1,35 @@
+package jenkins.plugins.jclouds.internal;
+
+import java.io.IOException;
+import java.util.Arrays;
+import javax.xml.bind.DatatypeConverter;
+
+import com.trilead.ssh2.crypto.PEMDecoder;
+import com.trilead.ssh2.signature.DSAPrivateKey;
+import com.trilead.ssh2.signature.DSASHA1Verify;
+import com.trilead.ssh2.signature.RSAPrivateKey;
+import com.trilead.ssh2.signature.RSASHA1Verify;
+
+/**
+ * Extracts a SSH public key from a SSH private key.
+ * @author Fritz Elfert
+ */
+public final class SSHPublicKeyExtractor {
+    /**
+     * Extracts a SSH public key from a PEM-encoded SSH private key.
+     * @param pem The PEM-encoded string (either RSA or DSA).
+     * @param passPhrase The passphrase to decrypt the private key (may be null, if the key is not encrypted).
+     * @return A public key string in the form "<pubkey-type> <pubkey-base64>"
+     * @throws IOException, if pem could not be decoded properly.
+     */
+    public static final String extract(final String pem, final String passPhrase) throws IOException {
+        final Object priv = PEMDecoder.decode(pem.toCharArray(), passPhrase);
+        if (priv instanceof RSAPrivateKey) {
+            return "ssh-rsa " + DatatypeConverter.printBase64Binary(RSASHA1Verify.encodeSSHRSAPublicKey(((RSAPrivateKey)priv).getPublicKey()));
+        }
+        if (priv instanceof DSAPrivateKey) {
+            return "ssh-dss " + DatatypeConverter.printBase64Binary(DSASHA1Verify.encodeSSHDSAPublicKey(((DSAPrivateKey)priv).getPublicKey()));
+        }
+        throw new IOException("should never happen");
+    }
+}

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/config.jelly
@@ -1,4 +1,4 @@
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:st="jelly:stapler">
     <f:entry title="Profile" field="profile">
         <f:textbox/>
     </f:entry>
@@ -20,11 +20,8 @@
     <f:entry title="Credential" field="credential">
         <f:password/>
     </f:entry>
-    <f:entry title="RSA Private Key" field="privateKey">
-        <f:textarea/>
-    </f:entry>
-    <f:entry title="Public Key" field="publicKey">
-        <f:textarea/>
+    <f:entry title="${%Cloud RSA key}" field="cloudGlobalKeyId">
+        <c:select/>
     </f:entry>
     <f:advanced>
         <f:entry title="Init Script Timeout" field="scriptTimeout">
@@ -42,6 +39,5 @@
             <st:include page="config.jelly" class="${descriptor.clazz}"/>
         </f:repeatable>
     </f:entry>
-    <f:validateButton title="${%Generate Key Pair}" progress="${%Generate...}" method="generateKeyPair" with="identity,credential"/>
-    <f:validateButton title="Test Connection" progress="${%Testing...}" method="testConnection" with="providerName,identity,credential,privateKey,endPointUrl"/>
+    <f:validateButton title="Test Connection" progress="${%Testing...}" method="testConnection" with="providerName,identity,credential,cloudGlobalKeyId,endPointUrl"/>
 </j:jelly>

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/help-privateKey.html
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/help-privateKey.html
@@ -1,4 +1,4 @@
 <div>
   RSA private key if you have one registerd with your cloud provider already. You need this key, if you want to connect to the slaves using SSH.
-  You can click on <i>Generate Key Pair</i> button if you want JClouds to generate a new pair to be used with the cloud provider.
+  The derived public key will be provisioned on created slave instances in the default-user's authorized_keys file.
 </div>

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
@@ -1,25 +1,25 @@
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <table width="100%" class="pane">
-    <f:section title="General Configuration">
-      <f:entry title="Name" field="name">
+    <f:section title="${%General Configuration}">
+      <f:entry title="${%Name}" field="name">
         <f:textbox/>
       </f:entry>
-      <f:entry title="Description" field="description">
+      <f:entry title="${%Description}" field="description">
         <f:textarea/>
       </f:entry>
-      <f:entry title="Labels" field="labelString">
+      <f:entry title="${%Labels}" field="labelString">
         <f:textbox/>
       </f:entry>
-      <f:entry title="Number of Executors" field="numExecutors">
-        <f:textbox/>
+      <f:entry title="${%Number of Executors}" field="numExecutors">
+        <f:textbox default="2" />
       </f:entry>
     </f:section>
     
-    <f:section title="Hardware Options">
+    <f:section title="${%Hardware Options}">
       <f:radioBlock inline="true" name="jclouds.useHardwareId" value="true"
-                    title="Specify Hardware ID" checked="${instance.hardwareId != ''}">
-        <f:entry title="Hardware Id" field="hardwareId">
+                    title="${%Specify Hardware Id}" checked="${instance.hardwareId != ''}">
+        <f:entry title="${%Hardware Id}" field="hardwareId">
           <f:select />
         </f:entry>
         <f:validateButton title="${%Check Hardware Id}" progress="${%Checking...}" method="validateHardwareId"
@@ -27,20 +27,20 @@
       </f:radioBlock>
       
       <f:radioBlock inline="true" name="jclouds.useHardwareId" value="false"
-                    title="Specify RAM and Cores" checked="${instance.hardwareId == ''}">
-        <f:entry title="Min. RAM (MB)" field="ram">
+                    title="${%Specify RAM and Cores}" checked="${instance.hardwareId == ''}">
+        <f:entry title="${%Min. RAM (MB)}" field="ram">
           <f:textbox default="512"/>
         </f:entry>
         
-        <f:entry title="Min. No.of Cores" field="cores">
+        <f:entry title="${%Min. No.of Cores}" field="cores">
           <f:textbox default="1"/>
         </f:entry>
       </f:radioBlock>
     </f:section>
 
-    <f:section title="Image/OS Options">
+    <f:section title="${%Image/OS Options}">
       <f:radioBlock inline="true" name="jclouds.imageSelectionOption" value="imageId"
-                    title="Specify Image ID" checked="${(instance.imageId != null) &amp;&amp; !instance.imageId.isEmpty()}">
+                    title="${%Specify Image ID}" checked="${(instance.imageId != null) &amp;&amp; !instance.imageId.isEmpty()}">
         <f:entry title="Image Id" field="imageId">
           <f:textbox />
         </f:entry>
@@ -50,8 +50,8 @@
       </f:radioBlock>
 
       <f:radioBlock inline="true" name="jclouds.imageSelectionOption" value="imageNameRegex"
-                    title="Specify Image Name Regex" checked="${((instance.imageId == null) || instance.imageId.isEmpty()) &amp;&amp; (instance.imageNameRegex != null) &amp;&amp; !instance.imageNameRegex.isEmpty()}">
-        <f:entry title="Image Name Regex" field="imageNameRegex">
+                    title="${%Specify Image Name Regex}" checked="${((instance.imageId == null) || instance.imageId.isEmpty()) &amp;&amp; (instance.imageNameRegex != null) &amp;&amp; !instance.imageNameRegex.isEmpty()}">
+        <f:entry title="${%Image Name Regex}" field="imageNameRegex">
             <f:textbox />
         </f:entry>
 
@@ -60,39 +60,39 @@
       </f:radioBlock>
 
       <f:radioBlock inline="true" name="jclouds.imageSelectionOption" value="osFamilyAndVersion"
-                    title="Specify OS Family and Version" checked="${((instance.imageId == null) || instance.imageId.isEmpty()) &amp;&amp; ((instance.imageNameRegex == null) || instance.imageNameRegex.isEmpty())}">
-        <f:entry title="OS Family" field="osFamily">
+                    title="${%Specify OS Family and Version}" checked="${((instance.imageId == null) || instance.imageId.isEmpty()) &amp;&amp; ((instance.imageNameRegex == null) || instance.imageNameRegex.isEmpty())}">
+        <f:entry title="${%OS Family}" field="osFamily">
           <f:textbox/>
         </f:entry>
         
-        <f:entry title="OS Version" field="osVersion">
+        <f:entry title="${%OS Version}" field="osVersion">
           <f:textbox/>
         </f:entry>
       </f:radioBlock>
     </f:section>
 
     <f:advanced>
-      <f:section title="Location Options">
-        <f:entry title="Location Id" field="locationId">
+      <f:section title="${%Location Options}">
+        <f:entry title="${%Location Id}" field="locationId">
           <f:select />
         </f:entry>
         <f:validateButton title="${%Check Location Id}" progress="${%Checking...}" method="validateLocationId"
                           with="providerName,identity,credential,endPointUrl,locationId"/>
       </f:section>
-      <f:section title="General Options">
-        <f:entry title="Override Retention Time" field="overrideRetentionTime">
-          <f:textbox />
+      <f:section title="${%General Options}">
+        <f:entry title="${%Override Retention Time}" field="overrideRetentionTime">
+          <f:textbox default="${instance.getDefaultRetentionTime()}" />
         </f:entry>
       
-        <f:entry title="Delay before spooling up (ms)" field="spoolDelayMs">
-          <f:textbox />
+        <f:entry title="${%Delay before spooling up (ms)}" field="spoolDelayMs">
+          <f:textbox default="0" />
         </f:entry>
       
-        <f:entry title="Init Script" field="initScript">
+        <f:entry title="${%Init Script}" field="initScript">
           <f:textarea />
         </f:entry>
       
-        <f:entry title="User Data (if supported by provider)" field="userData">
+        <f:entry title="${%User Data }(${%if supported by provider})" field="userData">
           <f:textarea />
         </f:entry>
 
@@ -105,28 +105,21 @@
           <f:checkbox />
         </f:entry>
       
-        <f:entry title="Allow Sudo" field="allowSudo">
+        <f:entry title="${%Allow Sudo}" field="allowSudo">
           <f:checkbox />
         </f:entry>
-        <f:entry title="Install Private Key" field="installPrivateKey">
+        <f:entry title="${%Install Private Key}" field="installPrivateKey">
           <f:checkbox />
         </f:entry>
         <f:entry title="Remote FS Root" field="fsRoot">
-          <f:textbox />
+          <f:textbox default="/jenkins" />
         </f:entry>
       
-        <f:entry title="Admin Username" field="vmUser">
-          <f:textbox />
-        </f:entry>
-        <f:entry title="Admin Password" field="vmPassword">
-          <f:password />
+        <f:entry title="${%Admin credentials}" field="adminCredentialsId">
+            <c:select/>
         </f:entry>
       
-        <f:entry title="${%Use Pre-installed Java}" field="preInstalledJava">
-          <f:checkbox />
-        </f:entry>
-      
-        <f:entry title="Custom JVM Options" field="jvmOptions">
+        <f:entry title="${%Custom JVM Options}" field="jvmOptions">
           <f:textbox />
         </f:entry>
       
@@ -134,11 +127,11 @@
           <f:checkbox />
         </f:entry>
 
-        <f:entry title="Networks" field="networks">
+        <f:entry title="${%Networks}" field="networks">
           <f:textbox />
         </f:entry>
 
-        <f:entry title="Security Groups" field="securityGroups">
+        <f:entry title="${%Security Groups}" field="securityGroups">
           <f:textbox />
         </f:entry>
       </f:section>
@@ -152,17 +145,17 @@
             <f:textbox default="15"/>
         </f:entry>
 
-      <f:section title="Open Stack Options">
-        <f:entry title="Assign Floating IP" field="assignFloatingIp">
+      <f:section title="${%OpenStack Options}">
+        <f:entry title="${%Assign Floating IP}" field="assignFloatingIp">
           <f:checkbox />
         </f:entry>
-        <f:entry title="Key Pair Name" field="keyPairName">
+        <f:entry title="${%Key Pair Name}" field="keyPairName">
           <f:textbox />
         </f:entry>
       </f:section>
 
-      <f:section title="CloudStack Options">
-        <f:entry title="Assign Public IP" field="assignPublicIp">
+      <f:section title="${%CloudStack Options}">
+        <f:entry title="${%Assign Public IP}" field="assignPublicIp">
           <f:checkbox default="true"/>
         </f:entry>
       </f:section>

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/help-credentialsId.html
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/help-credentialsId.html
@@ -1,0 +1,4 @@
+<div>
+  The credentials of the jenkins user. This user runs the the actual build jobs on the slave. Usually the username is "jenkins".
+</div>
+

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/help-jenkinsUser.html
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/help-jenkinsUser.html
@@ -1,3 +1,0 @@
-<div>
-  The user the Jenkins slave process will run as. Defaults to "jenkins".
-</div>

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudInsideJenkinsLiveTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudInsideJenkinsLiveTest.java
@@ -24,7 +24,7 @@ public class JCloudsCloudInsideJenkinsLiveTest extends HudsonTestCase {
 
         // TODO: this may need to vary per test
         cloud = new JCloudsCloud(fixture.getProvider() + "-profile", fixture.getProvider(), fixture.getIdentity(), fixture.getCredential(),
-                generatedKeys.get("private"), generatedKeys.get("public"), fixture.getEndpoint(), 1, 30, 600 * 1000, 600 * 1000, null,
+                null, fixture.getEndpoint(), 1, 30, 600 * 1000, 600 * 1000, null,
                 Collections.<JCloudsSlaveTemplate>emptyList());
     }
 

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudLiveTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudLiveTest.java
@@ -25,7 +25,7 @@ public class JCloudsCloudLiveTest extends TestCase {
 
         // TODO: this may need to vary per test
         cloud = new JCloudsCloud(fixture.getProvider() + "-profile", fixture.getProvider(), fixture.getIdentity(), fixture.getCredential(),
-                generatedKeys.get("private"), generatedKeys.get("public"), fixture.getEndpoint(), 1, 30, 600 * 1000, 600 * 1000, null,
+                null, fixture.getEndpoint(), 1, 30, 600 * 1000, 600 * 1000, null,
                 Collections.<JCloudsSlaveTemplate>emptyList());
     }
 

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudTest.java
@@ -40,14 +40,12 @@ public class JCloudsCloudTest {
         WebAssert.assertInputPresent(page2, "_.credential");
         WebAssert.assertInputPresent(page2, "_.instanceCap");
         WebAssert.assertInputPresent(page2, "_.retentionTime");
+        // WebAssert does not recognize select as input ?!
+        //WebAssert.assertInputPresent(page2, "_.cloudGlobalKeyId");
 
         HtmlForm configForm2 = page2.getFormByName("config");
-        assertNotNull(configForm2.getTextAreaByName("_.privateKey"));
-        assertNotNull(configForm2.getTextAreaByName("_.publicKey"));
-        HtmlButton generateKeyPairButton = configForm2.getButtonByCaption("Generate Key Pair");
         HtmlButton testConnectionButton = configForm2.getButtonByCaption("Test Connection");
         HtmlButton deleteCloudButton = configForm2.getButtonByCaption("Delete cloud");
-        assertNotNull(generateKeyPairButton);
         assertNotNull(testConnectionButton);
         assertNotNull(deleteCloudButton);
 
@@ -56,17 +54,17 @@ public class JCloudsCloudTest {
     @Test
     public void testConfigRoundtrip() throws Exception {
 
-        JCloudsCloud original = new JCloudsCloud("aws-profile", "aws-ec2", "identity", "credential", "privateKey", "publicKey", "endPointUrl", 1, 30,
+        JCloudsCloud original = new JCloudsCloud("aws-profile", "aws-ec2", "identity", "credential", "", "endPointUrl", 1, 30,
                 600 * 1000, 600 * 1000, null, Collections.<JCloudsSlaveTemplate>emptyList());
 
         j.getInstance().clouds.add(original);
         j.submit(j.createWebClient().goTo("configure").getFormByName("config"));
 
         j.assertEqualBeans(original, j.getInstance().clouds.getByName("aws-profile"),
-                "profile,providerName,identity,credential,privateKey,publicKey,endPointUrl,instanceCap,retentionTime");
+                "profile,providerName,identity,credential,cloudGlobalKeyId,endPointUrl,instanceCap,retentionTime");
 
         j.assertEqualBeans(original, JCloudsCloud.getByName("aws-profile"),
-                "profile,providerName,identity,credential,privateKey,publicKey,endPointUrl,instanceCap,retentionTime");
+                "profile,providerName,identity,credential,cloudGlobalKeyId,endPointUrl,instanceCap,retentionTime");
     }
 
 }

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
@@ -20,13 +20,13 @@ public class JCloudsSlaveTemplateTest extends HudsonTestCase {
         List<JCloudsSlaveTemplate> templates = new ArrayList<JCloudsSlaveTemplate>();
         templates.add(originalTemplate);
 
-        JCloudsCloud originalCloud = new JCloudsCloud("aws-profile", "aws-ec2", "identity", "credential", "privateKey", "publicKey", "endPointUrl", 1, 30,
+        JCloudsCloud originalCloud = new JCloudsCloud("aws-profile", "aws-ec2", "identity", "credential", "cloudGlobalKeyId", "endPointUrl", 1, 30,
                 600 * 1000, 600 * 1000, null, templates);
 
         hudson.clouds.add(originalCloud);
         submit(createWebClient().goTo("configure").getFormByName("config"));
 
-        assertEqualBeans(originalCloud, JCloudsCloud.getByName("aws-profile"), "profile,providerName,identity,credential,privateKey,publicKey,endPointUrl");
+        assertEqualBeans(originalCloud, JCloudsCloud.getByName("aws-profile"), "profile,providerName,identity,credential,cloudGlobalKeyId,endPointUrl");
 
         assertEqualBeans(originalTemplate, JCloudsCloud.getByName("aws-profile").getTemplate(name),
                 "name,cores,ram,osFamily,osVersion,labelString,description,initScript,numExecutors,stopOnTerminate");

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
@@ -13,9 +13,11 @@ public class JCloudsSlaveTemplateTest extends HudsonTestCase {
     public void testConfigRoundtrip() throws Exception {
         String name = "testSlave";
         JCloudsSlaveTemplate originalTemplate = new JCloudsSlaveTemplate(name, "imageId", null, "hardwareId", 1, 512, "osFamily", "osVersion", "locationId",
-                "jclouds-slave-type1 jclouds-type2", "Description", "initScript", null, "1", false, null, null, true,
-                "jvmOptions", false, null, false,
-                false, 5, 0, true, false, 0, "jenkins", true, "network1_id,network2_id", "security_group1,security_group2", null);
+                "jclouds-slave-type1 jclouds-type2", "Description", "initScript", null /* userData */ , "1" /* numExecutors */, false /* stopOnTerminate */,
+                "jvmOptions", false /* preExistingJenkinsUser */, null /* fsRoot */, false /* allowSudo */, false /* installPrivateKey */,
+                5 /* overrideRetentionTime */, 0 /* spoolDelayMs */, true /* assignFloatingIp */, false /* waitPhoneHome */, 0 /* waitPhoneHomeTimeout */,
+                null /* keyPairName */, true /* assignPublicIp */, "network1_id,network2_id", "security_group1,security_group2", null /* credentialsId */,
+                null /* adminCredentialsId */);
 
         List<JCloudsSlaveTemplate> templates = new ArrayList<JCloudsSlaveTemplate>();
         templates.add(originalTemplate);

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/internal/SSHPublicKeyExtractorTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/internal/SSHPublicKeyExtractorTest.java
@@ -60,7 +60,16 @@ public class SSHPublicKeyExtractorTest {
         + "xvh95OCM7fStsl3oXDQ=\n"
         + "-----END DSA PRIVATE KEY-----\n";
 
-    private static final String DSA_EXPECTED = "ssh-dss AAAAB3NzaC1kc3MAAACBAKSZnbqhjcMknRwf8dXLrlY1IzGTty81ir8BS+hduAb/xL7YjvSVqaHqLQy8hixR09rAmTwUhk+j5g2tHySlWE4T2RZoksuy1K6faJ4LWSMZu9RDFAqhBTFVGNbOd516/lTehu6Ai0MXrwMTdC60JmXwxA3zEcx0lDye6RHa5eYpAAAAFQCCLUgjAMsLlA3HIFKfgHsHp1erlwAAAIBOQqS9HzRP+6axnPSR9J45LuPP5Lb9d4ZaW28e1VEpP9a4ENV2L/fVIMvdzls2LYas6lKhLhVYHWR85q70FUgCjumgrDxqYiC0ajyM18Xdio5rTJ3xiJZEPvmJ2kxvjH4qudxZMp91LgcjYRQm3/dTP6Bd0mW5R56Jf5OFkzotugAAAIApl9gsVy3swP5PtBi2qw67IYw1j3JRfaMef4FNelJLsPvz2A0UG+1VpsZ+IT3s2rLqz0euXVSjKK3IJRwmSyBAQcU7hWyntPGVE4WLGgrSjM+M06LIhNL/E3wu50YRBDvOdN/xusxDjOdAWyZh2qY/Z9CbVix7lwTQus1oEumEMQ==";
+    private static final String DSA_EXPECTED = "ssh-dss AAAAB3NzaC1kc3MAAACBAKS"
+        + "ZnbqhjcMknRwf8dXLrlY1IzGTty81ir8BS+hduAb/xL7YjvSVqaHqLQy8hixR09rAmTw"
+        + "Uhk+j5g2tHySlWE4T2RZoksuy1K6faJ4LWSMZu9RDFAqhBTFVGNbOd516/lTehu6Ai0M"
+        + "XrwMTdC60JmXwxA3zEcx0lDye6RHa5eYpAAAAFQCCLUgjAMsLlA3HIFKfgHsHp1erlwA"
+        + "AAIBOQqS9HzRP+6axnPSR9J45LuPP5Lb9d4ZaW28e1VEpP9a4ENV2L/fVIMvdzls2LYa"
+        + "s6lKhLhVYHWR85q70FUgCjumgrDxqYiC0ajyM18Xdio5rTJ3xiJZEPvmJ2kxvjH4qudx"
+        + "ZMp91LgcjYRQm3/dTP6Bd0mW5R56Jf5OFkzotugAAAIApl9gsVy3swP5PtBi2qw67IYw"
+        + "1j3JRfaMef4FNelJLsPvz2A0UG+1VpsZ+IT3s2rLqz0euXVSjKK3IJRwmSyBAQcU7hWy"
+        + "ntPGVE4WLGgrSjM+M06LIhNL/E3wu50YRBDvOdN/xusxDjOdAWyZh2qY/Z9CbVix7lwT"
+        + "Qus1oEumEMQ==";
 
     @Test
     public void testExtractRSA() throws IOException {

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/internal/SSHPublicKeyExtractorTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/internal/SSHPublicKeyExtractorTest.java
@@ -1,0 +1,125 @@
+package jenkins.plugins.jclouds.internal;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Fritz Elfert
+ */
+public class SSHPublicKeyExtractorTest {
+
+    private static final String RSA_PEM = "-----BEGIN RSA PRIVATE KEY-----\n"
+        + "MIIEpQIBAAKCAQEAujBFmpi6nyHAK6RBaIkERTO/BGhgZ8h2zoqvT12+mSpjbNRF\n"
+        + "YN2oeMH1NsUMYLUdRzFlERqHo/U5pgS9SbXTvUujM153Voh6P+t4d822I2UN7vDc\n"
+        + "8MP4JTrUjaApOV0IeS1vem39QmlTXfc1ATFOskp2HoqypSTUv2xor2+OEni26iVx\n"
+        + "+CLydTZZpqG0yKUr9XlxWRgHm33kaqe4IP4rSWeOiRKDZTDEhZ5eqIpFfLCugOxz\n"
+        + "uUFR60aGgc84tAfbTb6UN1A0+FwWSa1aMl1ohUzEY+j6pIn2AeCHgJ290SxETGRz\n"
+        + "JBG2r33/9MAnScWdTlaoepgnp0IK+CfXzCH+uQIDAQABAoIBADOSdWUqEt9LMPil\n"
+        + "qbxz32vvtmRZKQL2QvpY7dBVDhtM43dcoM8A9s5kIzEFibUr1a1HoFAJgjLHFS3I\n"
+        + "OEo3hCv1zIHJE9MzQHF+HsNIhr/tGNvrebdzAMQHNKL6DxEllNhD3pIR70m69O2d\n"
+        + "MOBgsQSvnWI+VtdpiUhwldqqUrcIoWtj0X1KE7R/a0POmiRN7k6GrjreVllixegH\n"
+        + "CkPV8eeftQHdCn58S4/qZ8b6vCYXBhPN/cq+CmQ3jfKwcOg18ECFeoot665+SE2K\n"
+        + "bJSrI9gBfmMBNPxwUzsP7ehOScuyvwOCJiy3LhzhhhwJPbDelbW3Ts3y27Sk+033\n"
+        + "kBKphgECgYEA7sKLjoAMMa3XEAxPiVYx5cAdr862IzSPO3l26ySl9gw+KTQdTc12\n"
+        + "BhLDkpd2N+7ME8hOg0nYZI/l8yzR0icEDEAfuwpmWLQPVwdwi4ve4Nu9yFj23rSh\n"
+        + "23qduUIIwf9LLUzcRY9Ov+NVxnF+j6u6g7aPrVP8hF/onZ3Vb2mGT3kCgYEAx6Hz\n"
+        + "JN/RWv535kM9psmdq+FEKo2TXDSZaDcVJ+78lrE3JpxURKy+tL5GRoavSjJk/WXS\n"
+        + "MbDG0ZmRwx8Vzah10d4AKvW13fQHmyxeXn44zPks97hsrDzGMS91G/HycENeCm3s\n"
+        + "QLhLZINPO13IBQzQPiC5lzCRqIDrZr1SgYMtGUECgYEArx45xbbdOsLKbpbY714t\n"
+        + "Etop6/ytUn0GYRThx+4FW8X3AbmblKkR27p/f1Ff//5B6HCORXUwJfH1Mrq42m6L\n"
+        + "ZYDSxRkHoB/Q8IAgZ/ma60nAlOXLi+ToolX4wRxR2BgrR3qMROirVcqj6vzrWu0V\n"
+        + "y+1mzDZBi8Xck15kYWcAf+ECgYEAklv5lx9AriXCYd8KZC2Mm2ccQtZpI0Cs9+rq\n"
+        + "Z8yfAxwKAxS5819ysbCOdUZpXUx1HhJ4eFXSbfjZFOTFZ3IKb0MDfHuISqGOsgVl\n"
+        + "aoG/wwcsILHleqFT7NuOUF6iEAxT9fGBNDHplFdwz2WCL7GlOudjKaVCJPffngNP\n"
+        + "agRyHAECgYEA0a3Tr+0LpKbbQyKIw7BPcFJ5xY5OLsx3n1OkMptdp5ZsGEe926os\n"
+        + "4rhC8FhQaK4qSlwqa+hVTNAdTRrko+cbNaTroBfr9B2/sxSV4C1+m1fwqbRW0GPm\n"
+        + "Btm+l178Rt69FuUl0n3ZKZoKYu9z7A4QXBDhDITUM4rPT5wxf++Fqxw=\n"
+        + "-----END RSA PRIVATE KEY-----\n";
+
+    private static final String RSA_EXPECTED = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQ"
+        + "ABAAABAQC6MEWamLqfIcArpEFoiQRFM78EaGBnyHbOiq9PXb6ZKmNs1EVg3ah4wfU2x"
+        + "QxgtR1HMWURGoej9TmmBL1JtdO9S6MzXndWiHo/63h3zbYjZQ3u8Nzww/glOtSNoCk5"
+        + "XQh5LW96bf1CaVNd9zUBMU6ySnYeirKlJNS/bGivb44SeLbqJXH4IvJ1NlmmobTIpSv"
+        + "1eXFZGAebfeRqp7gg/itJZ46JEoNlMMSFnl6oikV8sK6A7HO5QVHrRoaBzzi0B9tNvp"
+        + "Q3UDT4XBZJrVoyXWiFTMRj6PqkifYB4IeAnb3RLERMZHMkEbavff/0wCdJxZ1OVqh6m"
+        + "CenQgr4J9fMIf65";
+
+    private static final String DSA_PEM = "-----BEGIN DSA PRIVATE KEY-----\n"
+        + "MIIBugIBAAKBgQCkmZ26oY3DJJ0cH/HVy65WNSMxk7cvNYq/AUvoXbgG/8S+2I70\n"
+        + "lamh6i0MvIYsUdPawJk8FIZPo+YNrR8kpVhOE9kWaJLLstSun2ieC1kjGbvUQxQK\n"
+        + "oQUxVRjWznedev5U3obugItDF68DE3QutCZl8MQN8xHMdJQ8nukR2uXmKQIVAIIt\n"
+        + "SCMAywuUDccgUp+AewenV6uXAoGATkKkvR80T/umsZz0kfSeOS7jz+S2/XeGWltv\n"
+        + "HtVRKT/WuBDVdi/31SDL3c5bNi2GrOpSoS4VWB1kfOau9BVIAo7poKw8amIgtGo8\n"
+        + "jNfF3YqOa0yd8YiWRD75idpMb4x+KrncWTKfdS4HI2EUJt/3Uz+gXdJluUeeiX+T\n"
+        + "hZM6LboCgYApl9gsVy3swP5PtBi2qw67IYw1j3JRfaMef4FNelJLsPvz2A0UG+1V\n"
+        + "psZ+IT3s2rLqz0euXVSjKK3IJRwmSyBAQcU7hWyntPGVE4WLGgrSjM+M06LIhNL/\n"
+        + "E3wu50YRBDvOdN/xusxDjOdAWyZh2qY/Z9CbVix7lwTQus1oEumEMQIUIjKV78Lb\n"
+        + "xvh95OCM7fStsl3oXDQ=\n"
+        + "-----END DSA PRIVATE KEY-----\n";
+
+    private static final String DSA_EXPECTED = "ssh-dss AAAAB3NzaC1kc3MAAACBAKSZnbqhjcMknRwf8dXLrlY1IzGTty81ir8BS+hduAb/xL7YjvSVqaHqLQy8hixR09rAmTwUhk+j5g2tHySlWE4T2RZoksuy1K6faJ4LWSMZu9RDFAqhBTFVGNbOd516/lTehu6Ai0MXrwMTdC60JmXwxA3zEcx0lDye6RHa5eYpAAAAFQCCLUgjAMsLlA3HIFKfgHsHp1erlwAAAIBOQqS9HzRP+6axnPSR9J45LuPP5Lb9d4ZaW28e1VEpP9a4ENV2L/fVIMvdzls2LYas6lKhLhVYHWR85q70FUgCjumgrDxqYiC0ajyM18Xdio5rTJ3xiJZEPvmJ2kxvjH4qudxZMp91LgcjYRQm3/dTP6Bd0mW5R56Jf5OFkzotugAAAIApl9gsVy3swP5PtBi2qw67IYw1j3JRfaMef4FNelJLsPvz2A0UG+1VpsZ+IT3s2rLqz0euXVSjKK3IJRwmSyBAQcU7hWyntPGVE4WLGgrSjM+M06LIhNL/E3wu50YRBDvOdN/xusxDjOdAWyZh2qY/Z9CbVix7lwTQus1oEumEMQ==";
+
+    @Test
+    public void testExtractRSA() throws IOException {
+        String pub = SSHPublicKeyExtractor.extract(RSA_PEM, null);
+        assertEquals(RSA_EXPECTED, pub);
+    }
+
+    @Test
+    public void testExtractDSA() throws IOException {
+        String pub = SSHPublicKeyExtractor.extract(DSA_PEM, null);
+        assertEquals(DSA_EXPECTED, pub);
+    }
+
+    @Test
+    public void testExtractInvalidPEM1() throws IOException {
+        boolean thrown = false;
+        try {
+            SSHPublicKeyExtractor.extract("", null);
+        } catch (IOException e) {
+            thrown = true;
+            assertEquals("Invalid PEM structure, '-----BEGIN...' missing", e.getMessage());
+        }
+        assertTrue(thrown);
+    }
+
+    @Test
+    public void testExtractInvalidPEM2() throws IOException {
+        boolean thrown = false;
+        try {
+            SSHPublicKeyExtractor.extract("-----BEGIN RSA PRIVATE KEY-----", null);
+        } catch (IOException e) {
+            thrown = true;
+            assertEquals("Invalid PEM structure, -----END RSA PRIVATE KEY----- missing", e.getMessage());
+        }
+        assertTrue(thrown);
+    }
+
+    @Test
+    public void testExtractInvalidPEM3() throws IOException {
+        boolean thrown = false;
+        try {
+            SSHPublicKeyExtractor.extract("-----BEGIN RSA PRIVATE KEY-----\nfoo\n-----END RSA PRIVATE KEY-----", null);
+        } catch (IOException e) {
+            thrown = true;
+            assertEquals("Invalid PEM structure, no data available", e.getMessage());
+        }
+        assertTrue(thrown);
+    }
+
+    @Test
+    public void testExtractInvalidPEM4() throws IOException {
+        boolean thrown = false;
+        try {
+            SSHPublicKeyExtractor.extract("-----BEGIN RSA PRIVATE KEY-----\nVGhpcyBpcyBhIGpva2UhCg==\n-----END RSA PRIVATE KEY-----", null);
+        } catch (IOException e) {
+            thrown = true;
+            assertEquals("Expected DER Sequence, but found type 84", e.getMessage());
+        }
+        assertTrue(thrown);
+    }
+
+}


### PR DESCRIPTION
Hi,

This is my next iteration which contains all the stuff we discussed:
- Use existing credentials framework of jenkins everywhere, except with the main cloud username/passsword.
- Auto-migration of config data from the old plugin version
- Added findbugs and PMD checks (both currently set to non-fatal, so the show a lot of errors/warnings but do _not_ fail the build)
- Added translation tags in the main config.jelly
- Removed JDK installer

Cheers
 -Fritz
